### PR TITLE
Make plumber-traceur work again, allow module path to be customised via option.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,0 +1,31 @@
+# plumber-traceur
+
+A plumber plugin to compile ecmascript 6 code using traceur.
+
+## Usage
+
+```javascript
+var all       = require('plumber-all')
+var glob      = require('plumber-glob')
+var traceur   = require('plumber-traceur')
+var concat    = require('plumber-concat')
+var write     = require('plumber-write')
+
+module.exports = function(pipelines) {
+  var sources = glob.within('app')
+  var writeToDist = write('dist')
+
+  pipelines['compile:js'] = [
+    sources('**/*.js'),
+    traceur.toAmd({
+      // this is optional
+      getModulePath: function(path) {
+        // this would change the path "app/app.js" to "yourAppName/app.js" etc.
+        return path.replace(/[^/]+/, 'yourAppName');
+      }
+    }),
+    concat('app'),
+    write('dist/assets')
+  ]
+}
+```

--- a/index.js
+++ b/index.js
@@ -6,10 +6,15 @@ var traceur = require('traceur');
 
 function transpileResource(options, resource) {
     try {
+        var modulePath = resource.path()._dirname + '/' + resource.filename();
+        if (options.getModulePath) {
+            modulePath = options.getModulePath(modulePath);
+        }
+
         output = traceur.compile(resource.data(), extend(options || {}, {
             filename: resource.filename(),
             sourceMap: true
-        }), resource.path()._dirname + '/' + resource.filename());
+        }), modulePath);
 
         return resource.withData(output);
     }
@@ -31,8 +36,9 @@ function transpileResource(options, resource) {
     }
 }
 
-function traceurOp(options) {
-    // FIXME: options?
+function traceurOp(options, userOptions) {
+    Object.assign(options, userOptions);
+
     return operation(function(resources) {
         return resources.map(transpileResource.bind(this, options));
     });

--- a/index.js
+++ b/index.js
@@ -1,78 +1,46 @@
 var operation = require('plumber').operation;
 var Report    = require('plumber').Report;
-var Rx        = require('plumber').Rx;
-var SourceMap = require('mercator').SourceMap;
 
 var extend = require('extend');
-
 var traceur = require('traceur');
 
-function transpile(resource, options) {
-    return Rx.Observable.create(function(observer) {
-        var output;
-        try {
-            var config = {file: resource.filename()};
-            output = traceur.compile(resource.data(), extend(options || {}, {
-                filename: resource.filename(),
-                sourceMap: true
-            }));
+function transpileResource(options, resource) {
+    var config = {file: resource.filename()};
 
-            if (output.errors.length === 0) {
-                // Successful!
-                observer.onNext(output);
-            } else {
-                var errors = output.errors.map(function(err) {
-                    // Annoyingly, error is provided as a string
-                    var details = err.match(/^(.+):(\d+):(\d+): (.*)/);
-                    return {
-                        filename: details[1],
-                        line:     Number(details[2]),
-                        column:   Number(details[3]),
-                        message:  details[4]
-                    };
-                });
-                observer.onError(errors);
-            }
-        } catch (err) {
-            // FIXME: map to error structure?
-            observer.onError([err]);
-        } finally {
-            observer.onCompleted();
-        }
-    });
+    try {
+        output = traceur.compile(resource.data(), extend(options || {}, {
+            filename: resource.filename(),
+            sourceMap: true
+        }), resource.path()._dirname + '/' + resource.filename());
+
+        return resource.withData(output);
+    }
+    catch (e) {
+        return new Report({
+            resource: resource,
+            type: 'error',
+            success: false,
+            errors: e.map(function (err) {
+                var details = err.match(/^(.+):(\d+):(\d+): (.*)/);
+                return {
+                    // filename: details[1],
+                    line:     Number(details[2]),
+                    column:   Number(details[3]),
+                    message:  details[4]
+                };
+            })
+        });
+    }
 }
 
 function traceurOp(options) {
     // FIXME: options?
-    return function() {
-        return operation(function(resources) {
-            return resources.flatMap(function(resource) {
-                return transpile(resource, options).map(function(output) {
-                    // TODO: remap on input source map
-                    var sourceMap = SourceMap.fromMapData(output.sourceMap);
-                    return resource.withData(output.js, sourceMap);
-                }).catch(function(errors) {
-                    var errorReports = errors.map(function(error) {
-                        return new Report({
-                            resource: resource,
-                            type: 'error', // FIXME: ?
-                            success: false,
-                            errors: [{
-                                column:  error.column,
-                                line:    error.line,
-                                message: error.message
-                                // No context
-                            }]
-                        });
-                    });
-                    return Rx.Observable.fromArray(errorReports);
-                });
-            });
-        });
-    };
+    return operation(function(resources) {
+        return resources.map(transpileResource.bind(this, options));
+    });
 };
 
 module.exports = {
-    toAmd:      traceurOp({modules: 'amd', moduleName: true}),
-    toCommonJs: traceurOp({modules: 'commonjs'})
+    toAmd:      traceurOp.bind(this, {modules: 'amd', moduleName: true}),
+    toCommonJs: traceurOp.bind(this, {modules: 'commonjs'})
 };

--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@ var extend = require('extend');
 var traceur = require('traceur');
 
 function transpileResource(options, resource) {
-    var config = {file: resource.filename()};
-
     try {
         output = traceur.compile(resource.data(), extend(options || {}, {
             filename: resource.filename(),

--- a/index.js
+++ b/index.js
@@ -10,14 +10,14 @@ var traceur = require('traceur');
 function transpile(resource, options) {
     return Rx.Observable.create(function(observer) {
         var output;
-	try {
+        try {
             var config = {file: resource.filename()};
-	    output = traceur.compile(resource.data(), extend(options || {}, {
+            output = traceur.compile(resource.data(), extend(options || {}, {
                 filename: resource.filename(),
                 sourceMap: true
             }));
 
-	    if (output.errors.length === 0) {
+            if (output.errors.length === 0) {
                 // Successful!
                 observer.onNext(output);
             } else {
@@ -33,10 +33,10 @@ function transpile(resource, options) {
                 });
                 observer.onError(errors);
             }
-	} catch (err) {
+        } catch (err) {
             // FIXME: map to error structure?
             observer.onError([err]);
-	} finally {
+        } finally {
             observer.onCompleted();
         }
     });

--- a/package.json
+++ b/package.json
@@ -4,13 +4,11 @@
   "description": "Traceur operation for Plumber pipelines",
   "main": "index",
   "dependencies": {
-    "mercator": "~0.1.4",
-    "highland": "~1.16.2",
-    "traceur": "~0.0.49",
+    "traceur": "~0.0.74",
     "extend": "~1.3.0"
   },
   "peerDependencies": {
-    "plumber": "~0.4.0"
+    "plumber": "~0.4.8"
   },
   "devDependencies": {
     "plumber-util-test": "~0.4.0",


### PR DESCRIPTION
This didn't seem to work with the latest plumber as per https://github.com/plumberjs/plumber-traceur/issues/3 so I seemed to have made it work again. I also added a module rewrite hook. And a README.
